### PR TITLE
Fix undo manager history on new/open files

### DIFF
--- a/src/TextEditor.java
+++ b/src/TextEditor.java
@@ -161,6 +161,7 @@ public class TextEditor extends JFrame {
     private void newFile() {
         if (confirmSave()) {
             textArea.setText("");
+            undoManager.discardAllEdits();
             currentFile = null;
             changed = false;
             setTitle("Simple Text Editor");
@@ -177,6 +178,7 @@ public class TextEditor extends JFrame {
                     while ((line = reader.readLine()) != null) {
                         textArea.append(line + "\n");
                     }
+                    undoManager.discardAllEdits();
                     currentFile = file.getPath();
                     changed = false;
                     setTitle("Simple Text Editor - " + file.getName());


### PR DESCRIPTION
## Summary
- reset undo history when creating a new file or opening a different file

## Testing
- `javac src/TextEditor.java src/Main.java src/test/TextEditorTest.java`
- `java -cp src test.TextEditorTest` *(fails: HeadlessException)*
- `javac src/TextEditor.java src/Main.java src/test/IntegrationTest.java`
- `java -cp src test.IntegrationTest` *(fails: HeadlessException)*

------
https://chatgpt.com/codex/tasks/task_e_684f19d277208327886801d20de0c655